### PR TITLE
feat!: General Triggers

### DIFF
--- a/src/index.bs
+++ b/src/index.bs
@@ -57,7 +57,6 @@ Status Text:
   }
 
   table.auto {
-    width: 100%;
     table-layout: auto;
   }
 
@@ -79,6 +78,17 @@ Status Text:
     border: 2px solid;
     padding: 4px 8px;
     vertical-align: top;
+  }
+
+  th.center {
+    text-align: center;
+    width: fit-content;
+  }
+
+  td.tick {
+    text-align: center;
+    vertical-align: middle;
+    font-weight: 800;
   }
 
   @media (prefers-color-scheme: dark) {

--- a/src/sections/triggers.md
+++ b/src/sections/triggers.md
@@ -1,47 +1,74 @@
 # Triggers # {#triggers}
 
-The Solid Protocol [[!SOLID]] requires an LDP container's state is modified when certain HTTP events occur on a contained resource. Thus, an HTTP event on a resource can trigger a [=Solid server=] to transmit [PREP] notification not only on that resource but also on its container.
+A [=Solid server=] implementing the [SUPER] on an LDP Resource SHOULD send a [PREP] notification when the state of the said resource is modified.
 
-A [=Solid server=] implementing the [SUPER] on an LDP Resource SHOULD send a [PREP] notification to a [=Solid client=] upon the following triggers:
+A [=Solid server=] MUST NOT transmit a [PREP] notification before the resource has been modified and a confirmation (if necessary) has been sent to (but might not have been received by) the agent that initiated the resource modification.
 
-## Resources and their Containers ## {#triggers-resource-and-their-containers}
+<div class="advisement">
+  <div class="marker">Implementation Guidance</div>
 
-When a request sent to the resource or a contained resource within it, with one of the following [[RFC9110#section-9|HTTP methods]] generates a response with any of the following [[RFC9110#section-15|HTTP status codes]]:
+  <p>The Solid Protocol [[SOLID]] requires an LDP container's state is modified when certain HTTP events occur on a contained resource. Thus, an HTTP event on a resource can trigger a [=Solid server=] to transmit a [PREP] notification on that resource or its container or both.
 
-<table class="numbered">
-  <caption> Notification Triggers (Resources and their Containers)
-  <tr>
-    <th> Request Method
-    <th> Response Status
-  <tr>
-    <td>
-      <code> [[RFC9110#section-9.3.4|PUT]] <br>
-      <code> [[RFC5789#section-2|PATCH]] <br>
-      <code> [[RFC9110#section-9.3.5|DELETE]]
-    <td>
-      <code> [[RFC9110#section-15.3.1|200 (OK)]] <br>
-      <code> [[RFC9110#section-15.3.5|204 (No Content)]] <br>
-</table>
+  <p>It follows that a [=Solid server=] ought to send [PREP] notification(s) on an resource and/or its container, when a request with one of the following [[RFC9110#section-9|HTTP methods]] generates a response with any of the following [[RFC9110#section-15|HTTP status codes]]:
 
-## Resources only ## {#triggers-resources-only}
+  <table class="numbered auto">
+    <caption> HTTP Notification Triggers
+    <tr>
+      <th rowspan=2> Request Method
+      <th rowspan=2> Response Status
+      <th colspan=2 class="center"> Notify
+    <tr>
+      <th class="center"> Resource
+      <th class="center"> Container
+    <tr>
+      <td rowspan=2>
+        <code> [[RFC9110#section-9.3.4|PUT]] <br>
+        <code> [[RFC5789#section-2|PATCH]] <br>
+      <td>
+        <code> [[RFC9110#section-15.3.1|200 (OK)]] <br>
+        <code> [[RFC9110#section-15.3.5|204 (No Content)]] <br>
+        <code> [[RFC9110#section-15.3.6|205 (Reset Content)]]
+      <td class="tick">
+        &check;
+      <td class="tick">
+        &check;
+    <tr>
+      <td>
+        <code> [[RFC9110#section-15.3.2|201 (Created)]] <br>
+      <td>
+      <td class="tick">
+        &check;
+    <tr>
+      <td rowspan=2>
+        <code> [[RFC9110#section-9.3.3|POST]]
+      <td>
+        <code> [[RFC9110#section-15.3.1|200 (OK)]] <br>
+        <code> [[RFC9110#section-15.3.5|204 (No Content)]] <br>
+        <code> [[RFC9110#section-15.3.6|205 (Reset Content)]]
+      <td class="tick">
+        &check;
+      <td class="tick">
+        &check;
+    <tr>
+      <td>
+        <code> [[RFC9110#section-15.3.2|201 (Created)]]
+      <td class="tick">
+        &check;
+    <tr>
+      <td>
+        <code> [[RFC9110#section-9.3.5|DELETE]]
+      <td>
+        <code> [[RFC9110#section-15.3.1|200 (OK)]] <br>
+        <code> [[RFC9110#section-15.3.5|204 (No Content)]] <br>
+      <td class="tick">
+        &check;
+      <td class="tick">
+        &check;
+  </table>
+  <br/>
 
-When a request sent to the resource with one of the following [[RFC9110#section-9|HTTP methods]] generates a response with any of the following [[RFC9110#section-15|HTTP status codes]]:
+  <p>Additionally, a [=Solid server=] ought to send [PREP] notification(s) on an resource and/or its container when modified at a later time as result of HTTP request that generates a <code>[[RFC9110#section-15.3.3|202 (Accepted)]]</code> status code.
 
-<table class="numbered">
-  <caption> Notification Triggers (Resource only)
-  <tr>
-    <th> Request Method
-    <th> Response Status
-  <tr>
-    <td>
-      <code> [[RFC9110#section-9.3.3|POST]] <br>
-    <td>
-      <code> [[RFC9110#section-15.3.1|200 (OK)]] <br>
-      <code> [[RFC9110#section-15.3.5|204 (No Content)]] <br>
-      <code> [[RFC9110#section-15.3.2|201 (Created)]] <br>
-      <code> [[RFC9110#section-15.3.6|205 (Reset Content)]]
-</table>
+  <p>A [=Solid server=] needs to ensure that a [PREP] notification is not transmitted before a response has been sent to the user agent that initiated the HTTP request that triggered the said notification.
 
-## Don't Jump the Gun ## {#trigger-timing}
-
-A [=Solid server=] MUST NOT transmit a [PREP] notification to a [=Solid client=] before a response has been sent to the user agent that initiated the request that triggered the said notification.
+</div>

--- a/src/sections/triggers.md
+++ b/src/sections/triggers.md
@@ -67,7 +67,7 @@ A [=Solid server=] MUST NOT transmit a [PREP] notification before the resource h
   </table>
   <br/>
 
-  <p>Additionally, a [=Solid server=] ought to send [PREP] notification(s) on an resource and/or its container when modified at a later time as result of HTTP request that generates a <code>[[RFC9110#section-15.3.3|202 (Accepted)]]</code> status code.
+  <p>Additionally, a [=Solid server=] ought to send [PREP] notification(s) on a resource and/or its container when modified at a later time as result of HTTP request that generates a <code>[[RFC9110#section-15.3.3|202 (Accepted)]]</code> status code.
 
   <p>A [=Solid server=] needs to ensure that a [PREP] notification is not transmitted before a response has been sent to the user agent that initiated the HTTP request that triggered the said notification.
 


### PR DESCRIPTION
Based on discussions in #1 and #3, the Triggers section has been completely re-written:

+ Normative requirements only specify notifications being triggered whenever the state of a LDP Resource is modified.
+ HTTP specific triggers are moved to implementation guidance:
  + PUT/PATCH requests being used to create a resource inside a container resulting in a 201 response are notification triggers.
  + PUT/PATCH requests successfully modifying a resource with 205 response are notification triggers.
  + Unless POST is being used to create a child resource, it should also trigger the resource's parent container to send notifications.
  + HTTP specific triggers have been combined into a single table for easier comprehension.